### PR TITLE
ergo_node_update.py scripted fool-proof way to make ergo node updates

### DIFF
--- a/02-python-script-automated/node-proficient-tutorial.md
+++ b/02-python-script-automated/node-proficient-tutorial.md
@@ -1,4 +1,4 @@
-# Ergo Node Proficient Tutorial
+# Ergo Node Python Script Setup Tutorial
 
 This assumes that you have basic knowledge of Raspberry Pi and Linux system administration.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Recommended after you've setup a node a few times, automated script for setup. Q
 
 # Update Tutorial: Updating your Ergo Node Version
 
-## [Ergo Node Update](/resources/ergo_node_update.py)
+## [Ergo Node Update](/resources/ergo_node_update_readme.py)
 To update your ergo node, use this script in resources. Run by `python3 ergo_node_update.py` from \resources directory.
 
 --------------------------------------

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Recommended after you've setup a node a few times, automated script for setup. Q
 ## [Docker Ergo Node (IN-WORK)](/03-docker-ergo-node/node-specialist-tutorial.md)
 (COMING SOON) Recommended docker ergo node for the super savvy. This will allow bootstrap from genesis or start from a snapshot for a quick sync.
 
+## [Ergo Node Update](/resources/ergo_node_update.py)
+To update your ergo node, use this script in resources.
+
 --------------------------------------
 
 ## Ergo Full Node Resources

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Recommended after you've setup a node a few times, automated script for setup. Q
 
 # Update Tutorial: Updating your Ergo Node Version
 
-## [Ergo Node Update](/resources/ergo_node_update_readme.py)
+## [Ergo Node Update](/resources/ergo_node_update_readme.md)
 To update your ergo node, use this script in resources. Run by `python3 ergo_node_update.py` from \resources directory.
 
 --------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tutorial: Running an Ergo Full Node on a Headless Raspberry Pi
+# Setup Tutorial: Running an Ergo Full Node on a Headless Raspberry Pi
 
 A tutorial on how to setup and run an Ergo Full Node on a Headless Raspberry Pi.
 
@@ -20,6 +20,9 @@ Recommended after you've setup a node a few times, automated script for setup. Q
 
 ## [Docker Ergo Node (IN-WORK)](/03-docker-ergo-node/node-specialist-tutorial.md)
 (COMING SOON) Recommended docker ergo node for the super savvy. This will allow bootstrap from genesis or start from a snapshot for a quick sync.
+
+
+# Update Tutorial: Updating your Ergo Node Version
 
 ## [Ergo Node Update](/resources/ergo_node_update.py)
 To update your ergo node, use this script in resources. Run by `python3 ergo_node_update.py` from \resources directory.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Recommended after you've setup a node a few times, automated script for setup. Q
 (COMING SOON) Recommended docker ergo node for the super savvy. This will allow bootstrap from genesis or start from a snapshot for a quick sync.
 
 ## [Ergo Node Update](/resources/ergo_node_update.py)
-To update your ergo node, use this script in resources.
+To update your ergo node, use this script in resources. Run by `python3 ergo_node_update.py` from \resources directory.
 
 --------------------------------------
 

--- a/resources/ergo_node_update.py
+++ b/resources/ergo_node_update.py
@@ -12,9 +12,10 @@ It performs the following tasks:
    - If already running the latest version, it provides proofs and exits.
 4. Prompts the user to confirm updating to the latest version.
 5. Downloads the latest Ergo Node JAR file.
-6. Updates the systemd service file to point to the new JAR version.
+6. Updates the systemd service file to point to the new JAR version throughout the file.
 7. Restarts the Ergo Node service to apply the changes.
-8. Provides confirmation and instructions to verify the update.
+8. Checks the logs to confirm the node is running the expected version.
+9. Provides confirmation and instructions to verify the update.
 
 Prerequisites:
 
@@ -23,201 +24,339 @@ Prerequisites:
 - You must have sudo privileges to move files and restart services.
 """
 
-import os
-import sys
-import subprocess
-import json
-import urllib.request
+# Import necessary modules for the script
+import os                   # For interacting with the operating system
+import sys                  # For system-specific parameters and functions
+import subprocess           # For running shell commands
+import json                 # For parsing JSON data
+import urllib.request       # For making HTTP requests
+import re                   # For regular expressions (pattern matching)
 
 def run_command(command, capture_output=True):
+    """
+    Executes a shell command and handles errors.
+
+    Parameters:
+    - command (str): The shell command to execute.
+    - capture_output (bool): Whether to capture and return the command's output.
+
+    Returns:
+    - str: The command's output if capture_output is True.
+
+    If the command fails, the script prints an error message and exits.
+    """
     try:
+        # Run the shell command
         result = subprocess.run(
             command,
-            stdout=subprocess.PIPE if capture_output else None,
-            stderr=subprocess.PIPE if capture_output else None,
-            shell=True,
-            check=True,
-            text=True
+            stdout=subprocess.PIPE if capture_output else None,  # Capture stdout if required
+            stderr=subprocess.PIPE if capture_output else None,  # Capture stderr if required
+            shell=True,          # Execute the command in the shell
+            check=True,          # Raise an exception if the command exits with a non-zero status
+            text=True            # Return output as a string (text), not bytes
         )
         if capture_output:
+            # Return the command's output, stripped of leading/trailing whitespace
             return result.stdout.strip()
         return ""
     except subprocess.CalledProcessError as e:
+        # Handle errors if the command fails
         print(f"\n[Error] Command failed: {command}")
         if capture_output:
+            # Print the error output from the command
             print(f"[Error] Error Output: {e.stderr.strip()}\n")
         else:
+            # Inform the user that the command exited with a non-zero status
             print(f"[Error] Command exited with non-zero status.\n")
+        # Exit the script with an error code
         sys.exit(1)
 
 def get_current_ergo_version(node_path):
-    # Assuming the JAR file is named as ergo-<version>.jar
+    """
+    Determines the current version of the Ergo Node installed.
+
+    Parameters:
+    - node_path (str): The path to the Ergo Node installation directory.
+
+    Returns:
+    - str or None: The current version as a string if found, otherwise None.
+    """
     try:
+        # List all files in the node installation directory
         files = os.listdir(node_path)
     except FileNotFoundError:
+        # Return None if the directory is not found
         return None
+    # Iterate over the files to find the JAR file
     for file in files:
+        # Look for files that start with 'ergo-' and end with '.jar'
         if file.startswith("ergo-") and file.endswith(".jar"):
+            # Extract and return the version number from the file name
             return file.replace("ergo-", "").replace(".jar", "")
+    # Return None if no matching JAR file is found
     return None
 
 def get_latest_ergo_version():
+    """
+    Fetches the latest mainnet release version of the Ergo Node from GitHub.
+
+    Returns:
+    - str: The latest version as a string.
+
+    If it fails to fetch the version, the script prints an error message and exits.
+    """
     print("[Info] Fetching the latest Ergo mainnet release version from GitHub...")
     try:
+        # GitHub API URL for Ergo releases
         url = "https://api.github.com/repos/ergoplatform/ergo/releases"
+        # Open the URL and read the response
         with urllib.request.urlopen(url) as response:
             data = response.read()
+            # Parse the JSON data
             releases = json.loads(data.decode('utf-8'))
 
+            # Iterate over the releases
             for release in releases:
                 # Skip pre-releases and drafts
                 if not release['prerelease'] and not release['draft']:
+                    # Get the tag name (version) of the release
                     version_tag = release['tag_name']
-                    # Remove the leading 'v' if present
+                    # Remove the leading 'v' if present (e.g., 'v5.0.23' becomes '5.0.23')
                     if version_tag.startswith('v'):
                         version_tag = version_tag[1:]
                     print(f"[Info] Latest mainnet release version: {version_tag}\n")
+                    # Return the latest version found
                     return version_tag
+        # If no suitable release is found, print an error and exit
         print("[Error] No suitable mainnet release found.")
         sys.exit(1)
     except Exception as e:
+        # Handle exceptions during the HTTP request or JSON parsing
         print(f"[Error] Failed to fetch the latest release version: {e}")
         sys.exit(1)
 
 def update_ergo_node(node_path, new_version):
+    """
+    Downloads the latest Ergo Node JAR file.
+
+    Parameters:
+    - node_path (str): The path to the Ergo Node installation directory.
+    - new_version (str): The new version to download.
+
+    If the download fails, the script prints an error message and exits.
+    """
+    # Change the current working directory to the node installation directory
     os.chdir(node_path)
 
-    # Download the new Ergo JAR
+    # Construct the download command using wget
     download_ergo_jar = f"wget -q https://github.com/ergoplatform/ergo/releases/download/v{new_version}/ergo-{new_version}.jar"
     print(f"[Info] Downloading Ergo Node version {new_version}...")
+    # Execute the download command
     run_command(download_ergo_jar)
     print(f"[Success] Ergo Node version {new_version} downloaded successfully.\n")
 
-def update_systemd_service(node_path, new_version):
+def update_systemd_service(node_path, current_version, new_version):
+    """
+    Updates the systemd service file to point to the new JAR version throughout the file.
+
+    Parameters:
+    - node_path (str): The path to the Ergo Node installation directory.
+    - current_version (str or None): The current version installed.
+    - new_version (str): The new version to update to.
+
+    If updating the service file fails, the script prints an error message and exits.
+    """
+    # Path to the systemd service file
     service_file_path = "/etc/systemd/system/ergo-node.service"
 
     # Read the existing service file
     try:
         with open(service_file_path, "r") as service_file:
+            # Read the entire content of the service file
             service_contents = service_file.read()
     except Exception as e:
+        # Handle exceptions if the file cannot be read
         print(f"\n[Error] Failed to read service file: {e}\n")
         sys.exit(1)
 
-    # Replace the ExecStart line with the new version
-    new_exec_start = f"ExecStart=/usr/bin/java -Xmx4g -jar {node_path}/ergo-{new_version}.jar --mainnet -c {node_path}/ergo.conf"
-    service_lines = service_contents.splitlines()
-    for i, line in enumerate(service_lines):
-        if line.startswith("ExecStart="):
-            service_lines[i] = new_exec_start
-            break
+    # Define a regular expression pattern to match the old JAR file name
+    # This pattern matches 'ergo-<version>.jar', where <version> consists of digits and dots
+    old_jar_pattern = r'ergo-\d+\.\d+\.\d+\.jar'
 
-    new_service_contents = "\n".join(service_lines)
+    # Define the new JAR file name using the new version
+    new_jar = f'ergo-{new_version}.jar'
 
-    # Write the updated service file to a temporary location
+    # Replace all occurrences of the old JAR file name with the new one in the service file content
+    updated_service_contents = re.sub(old_jar_pattern, new_jar, service_contents)
+
+    # Write the updated service file to a temporary location in the node installation directory
     temp_service_file = os.path.join(node_path, 'ergo-node.service')
     try:
         with open(temp_service_file, "w") as service_file:
-            service_file.write(new_service_contents)
+            # Write the updated service content to the temporary file
+            service_file.write(updated_service_contents)
         print(f"[Success] Updated service file created at {temp_service_file}")
     except Exception as e:
+        # Handle exceptions if the file cannot be written
         print(f"\n[Error] Failed to write updated service file: {e}\n")
         sys.exit(1)
 
-    # Move the updated service file to /etc/systemd/system/
+    # Move the updated service file to the systemd directory
     run_command(f"sudo mv {temp_service_file} {service_file_path}")
+    # Set the correct permissions for the service file
     run_command(f"sudo chmod 644 {service_file_path}")
     print(f"[Success] Service file updated at {service_file_path}\n")
 
 def restart_ergo_node_service():
+    """
+    Restarts the Ergo Node service using systemd.
+
+    If restarting the service fails, the script prints an error message and exits.
+    """
     print("[Info] Restarting Ergo Node service...")
-    # Use the actual command instead of the alias
+    # Reload the systemd daemon to recognize changes
     run_command("sudo systemctl daemon-reload")
+    # Restart the Ergo Node service
     run_command("sudo systemctl restart ergo-node.service")
     print("[Success] Ergo Node service restarted.\n")
 
+def check_node_version_in_logs(version):
+    """
+    Checks the Ergo Node logs to confirm it's running the expected version.
+
+    Parameters:
+    - version (str): The version to check for in the logs.
+
+    If the version is found in the logs, it prints a confirmation message.
+    Otherwise, it prints a warning.
+    """
+    print("\n[Info] Checking the Ergo Node logs for version information...")
+    try:
+        # Construct the command to search the logs for the version
+        # This command searches for lines containing 'Version: <version>'
+        log_output = run_command(f"sudo journalctl -u ergo-node.service | grep -E 'Version:? {version}' | tail -1")
+        if version in log_output:
+            # If the version is found in the logs, print a proof message
+            print(f"[Proof] Ergo Node is running version {version} as per logs.")
+        else:
+            # If the version is not found, print a warning with the last matching log entry
+            print(f"[Warning] Could not confirm the node version from the logs. Last version in logs: {log_output}")
+    except Exception as e:
+        # Handle exceptions if the log check fails
+        print(f"\n[Error] Failed to check logs: {e}\n")
+
 def main():
+    """
+    The main function orchestrates the update process.
+
+    It performs the following steps:
+    - Prints the script header and prerequisites.
+    - Determines the node installation path.
+    - Gets the current and latest Ergo Node versions.
+    - Compares versions and prompts for update if necessary.
+    - Performs the update and restarts the service.
+    - Checks the logs to confirm the node is running the expected version.
+    """
+    # Print the script header
     print("\n#############################################")
     print("#         Ergo Node Update Script           #")
     print("#############################################\n")
 
+    # Print prerequisites
     print("Prerequisites:")
     print("- This script assumes that you have installed the Ergo Node using 'ergo_node_setup.py'.")
     print("- The script manages the service directly using system commands.\n")
 
-    # Get the user's home directory
+    # Get the user's home directory (e.g., '/home/username')
     home_dir = os.path.expanduser("~")
 
-    # Node installation directory (default: ~/ergo-node)
+    # Define the node installation directory (default: '~/ergo-node')
     node_path = os.path.join(home_dir, "ergo-node")
 
-    # Get the current Ergo version
+    # Get the current Ergo Node version installed
     current_version = get_current_ergo_version(node_path)
     if not current_version:
+        # If the version cannot be determined, print a warning
         print("[Warning] Could not determine the current Ergo Node version.")
     else:
+        # Print the current version
         print(f"[Info] Current Ergo Node version: {current_version}")
 
-    # Get the latest Ergo version from GitHub
+    # Get the latest Ergo Node version from GitHub
     latest_version = get_latest_ergo_version()
 
-    # If current_version is known and equals latest_version
+    # Check if the current version is known and matches the latest version
     if current_version and current_version == latest_version:
         print("[Info] You are already running the latest Ergo Node version.")
-        # Print proofs
+        # Provide proofs to confirm the node is up-to-date
+
+        # Print the current version detected from the JAR file
         print("\n[Proof] Current Ergo Node version detected from JAR file: {}".format(current_version))
 
-        # Verify the version in the systemd service file
+        # Verify that the systemd service file points to the correct JAR version
         service_file_path = "/etc/systemd/system/ergo-node.service"
         try:
             with open(service_file_path, "r") as service_file:
+                # Read the service file content
                 service_contents = service_file.read()
-            service_points_to_correct_version = False
-            for line in service_contents.splitlines():
-                if line.startswith("ExecStart="):
-                    if f"ergo-{current_version}.jar" in line:
-                        service_points_to_correct_version = True
-                        print("[Proof] Systemd service file points to the correct JAR version.")
-                    else:
-                        print("[Warning] Systemd service file does not point to the expected JAR version.")
-            if not service_points_to_correct_version:
-                print("[Warning] The ExecStart line in the service file does not match the current version.")
+            if f"ergo-{current_version}.jar" in service_contents:
+                # If the service file points to the correct JAR version, print a proof message
+                print("[Proof] Systemd service file points to the correct JAR version.")
+            else:
+                # If not, print a warning
+                print("[Warning] Systemd service file does not point to the expected JAR version.")
+            # Indicate that the service file has been checked
             print("[Proof] Service file checked: {}".format(service_file_path))
         except Exception as e:
+            # Handle exceptions if the service file cannot be read
             print(f"\n[Error] Failed to read service file: {e}\n")
 
         # Check the status of the Ergo Node service
         print("\n[Info] Checking the status of the Ergo Node service...")
         run_command("systemctl status ergo-node.service", capture_output=False)
+
+        # Check the logs to confirm the node is running the expected version
+        check_node_version_in_logs(current_version)
+
+        # Exit the script since the node is already up-to-date
         sys.exit(0)
 
-    # Prompt user to confirm updating to the latest version, default to 'yes' on Enter
+    # Prompt the user to confirm updating to the latest version
     if current_version:
+        # If the current version is known, include it in the prompt
         prompt_message = f"Do you want to update from version {current_version} to the latest version {latest_version}? ([yes]/no). Press Enter for default yes: "
     else:
+        # If the current version is unknown, adjust the prompt accordingly
         prompt_message = f"Do you want to install the latest Ergo Node version {latest_version}? ([yes]/no). Press Enter for default yes: "
 
+    # Get the user's input and convert it to lowercase
     confirm = input(prompt_message).strip().lower()
     if confirm in ['no', 'n']:
+        # If the user answers 'no', cancel the update and exit
         print("Update canceled.")
         sys.exit(0)
 
-    # Perform the update
+    # Proceed to perform the update
     update_ergo_node(node_path, latest_version)
-    update_systemd_service(node_path, latest_version)
+    update_systemd_service(node_path, current_version, latest_version)
 
-    # Restart the Ergo Node service using the actual command
+    # Restart the Ergo Node service to apply the changes
     restart_ergo_node_service()
 
+    # Check the logs to confirm the node is running the new version
+    check_node_version_in_logs(latest_version)
+
+    # Print the update completion message
     print("#############################################")
     print("#      Ergo Node Update Complete!           #")
     print("#############################################\n")
 
     print(f"[Success] Your Ergo Node has been updated to version {latest_version}.\n")
 
-    # Suggest checking the status using the command
+    # Provide instructions to check the service status
     print("You can check the status of your Ergo Node service using:")
     print("  systemctl status ergo-node.service\n")
 
+# Entry point of the script
 if __name__ == "__main__":
     main()

--- a/resources/ergo_node_update.py
+++ b/resources/ergo_node_update.py
@@ -16,7 +16,7 @@ It performs the following tasks:
 7. Updates the systemd service file to point to the new JAR version throughout the file.
 8. Restarts the Ergo Node service to apply the changes.
 9. Checks the status of the Ergo Node service.
-10. Prints the node HTTP address for easy access.
+10. Prints the node HTTP address as a clickable hyperlink for easy access.
 11. Prompts the user to view the Ergo Node logs or exit.
 
 Prerequisites:
@@ -291,6 +291,22 @@ def get_node_port(ergo_conf_path):
         pass
     return default_port
 
+def create_clickable_link(url, text=None):
+    """
+    Creates a clickable hyperlink in the terminal using ANSI escape sequences.
+
+    Parameters:
+    - url (str): The URL to link to.
+    - text (str or None): The text to display. If None, the URL is displayed.
+
+    Returns:
+    - str: The formatted string with ANSI escape sequences for clickable links.
+    """
+    if text is None:
+        text = url
+    escape_url = url.replace("\\", "\\\\").replace(";", "\\;")
+    return f"\033]8;;{escape_url}\033\\{text}\033]8;;\033\\"
+
 def main():
     """
     The main function orchestrates the update process.
@@ -303,7 +319,7 @@ def main():
     - Compares versions and prompts for update if necessary.
     - Performs the update and restarts the service.
     - Checks the status of the Ergo Node service.
-    - Prints the node HTTP address for easy access.
+    - Prints the node HTTP address as a clickable hyperlink.
     - Prompts the user to view the Ergo Node logs or exit.
     """
     # Check if the script is run with root privileges
@@ -368,14 +384,16 @@ def main():
         print("\n[Info] Checking the status of the Ergo Node service...")
         run_command("systemctl status ergo-node.service", capture_output=False)
 
-        # Display the node HTTP address
+        # Display the node HTTP address as a clickable link
         ip_address = get_ipv4_address()
         ergo_conf_path = os.path.join(node_path, "ergo.conf")
         node_port = get_node_port(ergo_conf_path)
         node_url = f"http://{ip_address}:{node_port}/panel/"
 
+        clickable_link = create_clickable_link(node_url)
+
         print(f"\nYou can access your Ergo Node in a web browser at:")
-        print(f"  {node_url}\n")
+        print(f"  {clickable_link}\n")
 
         # Prompt the user to run 'ergo-logs' or exit
         prompt_message = "Do you want to view the Ergo Node logs now? Press Enter for yes, or type 'no' to exit: "
@@ -415,14 +433,16 @@ def main():
     print("\n[Info] Checking the status of the Ergo Node service...")
     run_command("systemctl status ergo-node.service", capture_output=False)
 
-    # Display the node HTTP address
+    # Display the node HTTP address as a clickable link
     ip_address = get_ipv4_address()
     ergo_conf_path = os.path.join(node_path, "ergo.conf")
     node_port = get_node_port(ergo_conf_path)
     node_url = f"http://{ip_address}:{node_port}/panel/"
 
+    clickable_link = create_clickable_link(node_url)
+
     print(f"\nYou can access your Ergo Node in a web browser at:")
-    print(f"  {node_url}\n")
+    print(f"  {clickable_link}\n")
 
     # Prompt the user to run 'ergo-logs' or exit
     prompt_message = "Do you want to view the Ergo Node logs now? Press Enter for yes, or type 'no' to exit: "

--- a/resources/ergo_node_update.py
+++ b/resources/ergo_node_update.py
@@ -154,9 +154,9 @@ def main():
         print("[Info] You are already running the latest Ergo Node version.")
         sys.exit(0)
 
-    # Prompt user to confirm updating to the latest version
-    confirm = input(f"Do you want to update to the latest version {latest_version}? (yes/no): ").strip().lower()
-    if confirm not in ['yes', 'y']:
+    # Prompt user to confirm updating to the latest version, default to 'yes' on Enter
+    confirm = input(f"Do you want to update to the latest version {latest_version}? ([yes]/no). Press Enter for default yes: ").strip().lower()
+    if confirm in ['no', 'n']:
         print("Update canceled.")
         sys.exit(0)
 

--- a/resources/ergo_node_update.py
+++ b/resources/ergo_node_update.py
@@ -4,7 +4,6 @@ import sys
 import subprocess
 import json
 import urllib.request
-import getpass
 
 def run_command(command, capture_output=True):
     try:
@@ -14,9 +13,7 @@ def run_command(command, capture_output=True):
             stderr=subprocess.PIPE,
             shell=True,
             check=True,
-            executable="/bin/bash",  # Use bash shell to recognize aliases
-            text=True,
-            env=os.environ.copy()
+            text=True
         )
         if capture_output:
             return result.stdout.strip()
@@ -90,7 +87,7 @@ def update_systemd_service(node_path, new_version):
     new_service_contents = "\n".join(service_lines)
 
     # Write the updated service file to a temporary location
-    temp_service_file = os.path.join(os.getcwd(), 'ergo-node.service')
+    temp_service_file = os.path.join(ergo_node_path, 'ergo-node.service')
     try:
         with open(temp_service_file, "w") as service_file:
             service_file.write(new_service_contents)
@@ -105,9 +102,10 @@ def update_systemd_service(node_path, new_version):
     print(f"[Success] Service file updated at {service_file_path}\n")
 
 def restart_ergo_node_service():
-    print("[Info] Restarting Ergo Node service using alias 'ergo-restart'...")
-    # Use the 'ergo-restart' alias set up by ergo_node_setup.py
-    run_command("ergo-restart")
+    print("[Info] Restarting Ergo Node service...")
+    # Use the actual command instead of the alias
+    run_command("sudo systemctl daemon-reload")
+    run_command("sudo systemctl restart ergo-node.service")
     print("[Success] Ergo Node service restarted.\n")
 
 def main():
@@ -117,21 +115,7 @@ def main():
 
     print("Prerequisites:")
     print("- This script assumes that you have installed the Ergo node using 'ergo_node_setup.py'.")
-    print("- The script uses the aliases set up by 'ergo_node_setup.py' for service management.\n")
-
-    # Ensure that the aliases are available
-    shell = os.environ.get('SHELL', '/bin/bash')
-    if shell.endswith('bash'):
-        bashrc_path = os.path.expanduser("~/.bashrc")
-        if os.path.exists(bashrc_path):
-            # Source the .bashrc to load aliases
-            run_command(f"source {bashrc_path}")
-        else:
-            print("[Error] .bashrc not found. Aliases may not be available.")
-            sys.exit(1)
-    else:
-        print("[Warning] Non-bash shell detected. Aliases may not be available.")
-        sys.exit(1)
+    print("- The script manages the service directly using system commands.\n")
 
     # Get the user's home directory
     home_dir = os.path.expanduser("~")
@@ -164,7 +148,7 @@ def main():
     update_ergo_node(node_path, latest_version)
     update_systemd_service(node_path, latest_version)
 
-    # Restart the Ergo node service using the alias
+    # Restart the Ergo node service using the actual command
     restart_ergo_node_service()
 
     print("#############################################")
@@ -174,8 +158,8 @@ def main():
     print(f"[Success] Your Ergo Node has been updated to version {latest_version}.\n")
 
     # Suggest checking the status using the alias
-    print("You can check the status of your Ergo Node service using the alias:")
-    print("  ergo-status\n")
+    print("You can check the status of your Ergo Node service using:")
+    print("  systemctl status ergo-node.service\n")
 
 if __name__ == "__main__":
     main()

--- a/resources/ergo_node_update.py
+++ b/resources/ergo_node_update.py
@@ -25,9 +25,8 @@ def run_command(command, capture_output=True):
 
 def get_current_ergo_version(node_path):
     # Assuming the JAR file is named as ergo-<version>.jar
-    ergo_node_path = os.path.join(node_path, "ergo-node")
     try:
-        files = os.listdir(ergo_node_path)
+        files = os.listdir(node_path)
     except FileNotFoundError:
         return None
     for file in files:
@@ -52,15 +51,14 @@ def get_latest_ergo_version():
                         version_tag = version_tag[1:]
                     print(f"[Info] Latest mainnet release version: {version_tag}\n")
                     return version_tag
-            print("[Error] No suitable mainnet release found.")
-            sys.exit(1)
+        print("[Error] No suitable mainnet release found.")
+        sys.exit(1)
     except Exception as e:
         print(f"[Error] Failed to fetch the latest release version: {e}")
         sys.exit(1)
 
 def update_ergo_node(node_path, new_version):
-    ergo_node_path = os.path.join(node_path, "ergo-node")
-    os.chdir(ergo_node_path)
+    os.chdir(node_path)
 
     # Download the new Ergo JAR
     download_ergo_jar = f"wget -q https://github.com/ergoplatform/ergo/releases/download/v{new_version}/ergo-{new_version}.jar"
@@ -80,7 +78,7 @@ def update_systemd_service(node_path, new_version):
         sys.exit(1)
 
     # Replace the ExecStart line with the new version
-    new_exec_start = f"ExecStart=/usr/bin/java -Xmx4g -jar {node_path}/ergo-node/ergo-{new_version}.jar --mainnet -c {node_path}/ergo-node/ergo.conf"
+    new_exec_start = f"ExecStart=/usr/bin/java -Xmx4g -jar {node_path}/ergo-{new_version}.jar --mainnet -c {node_path}/ergo.conf"
     service_lines = service_contents.splitlines()
     for i, line in enumerate(service_lines):
         if line.startswith("ExecStart="):
@@ -90,7 +88,7 @@ def update_systemd_service(node_path, new_version):
     new_service_contents = "\n".join(service_lines)
 
     # Write the updated service file to a temporary location
-    temp_service_file = os.path.join(ergo_node_path, 'ergo-node.service')
+    temp_service_file = os.path.join(node_path, 'ergo-node.service')
     try:
         with open(temp_service_file, "w") as service_file:
             service_file.write(new_service_contents)
@@ -123,8 +121,8 @@ def main():
     # Get the user's home directory
     home_dir = os.path.expanduser("~")
 
-    # Assume the node is installed in the user's home directory
-    node_path = home_dir
+    # Node installation directory (default: ~/ergo-node)
+    node_path = os.path.join(home_dir, "ergo-node")
 
     # Get the current Ergo version
     current_version = get_current_ergo_version(node_path)

--- a/resources/ergo_node_update.py
+++ b/resources/ergo_node_update.py
@@ -43,6 +43,21 @@ def check_root_privileges():
         print("  sudo python3 {}".format(sys.argv[0]))
         sys.exit(1)
 
+def get_home_directory():
+    """
+    Returns the home directory of the user running the script.
+    If run with sudo, returns the home directory of the user who invoked sudo.
+    """
+    if os.getenv("SUDO_USER"):
+        # The script is run with sudo
+        sudo_user = os.getenv("SUDO_USER")
+        # Get the home directory of the sudo user
+        home_dir = os.path.expanduser(f"~{sudo_user}")
+    else:
+        # The script is not run with sudo
+        home_dir = os.path.expanduser("~")
+    return home_dir
+
 def run_command(command, capture_output=True, timeout=None):
     """
     Executes a shell command and handles errors.
@@ -289,10 +304,12 @@ def main():
     print("- The script manages the service directly using system commands.")
     print("- You must run this script with 'sudo'.\n")
 
-    # Manually set the node installation directory
-    node_path = "/home/yourusername/ergo-node"  # Replace with your actual path
+    # Get the home directory of the user who invoked sudo
+    home_dir = get_home_directory()
+    node_path = os.path.join(home_dir, "ergo-node")
 
     # Debug statements
+    print(f"[Debug] Home Directory: {home_dir}")
     print(f"[Debug] Node Installation Path: {node_path}")
 
     # Get the current Ergo Node version installed

--- a/resources/ergo_node_update.py
+++ b/resources/ergo_node_update.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+
+def run_command(command, capture_output=True):
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            check=True,
+            text=True
+        )
+        if capture_output:
+            return result.stdout.strip()
+        return ""
+    except subprocess.CalledProcessError as e:
+        print(f"\n[Error] Command failed: {command}")
+        print(f"[Error] Error Output: {e.stderr.strip()}\n")
+        sys.exit(1)
+
+def run_sudo_command(command):
+    try:
+        sudo_command = f"sudo {command}"
+        subprocess.run(
+            sudo_command,
+            shell=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        print(f"[Success] Executed: {sudo_command}")
+    except subprocess.CalledProcessError as e:
+        print(f"\n[Error] Failed to execute: {sudo_command}")
+        print(f"[Error] Error Output: {e.stderr.strip()}\n")
+        sys.exit(1)
+
+def get_current_ergo_version(node_path):
+    # Assuming the JAR file is named as ergo-<version>.jar
+    ergo_node_path = os.path.join(node_path, "ergo-node")
+    files = os.listdir(ergo_node_path)
+    for file in files:
+        if file.startswith("ergo-") and file.endswith(".jar"):
+            return file.replace("ergo-", "").replace(".jar", "")
+    return None
+
+def update_ergo_node(node_path, new_version):
+    ergo_node_path = os.path.join(node_path, "ergo-node")
+    os.chdir(ergo_node_path)
+
+    # Download the new Ergo JAR
+    download_ergo_jar = f"wget -q https://github.com/ergoplatform/ergo/releases/download/v{new_version}/ergo-{new_version}.jar"
+    print(f"[Info] Downloading Ergo Node version {new_version}...")
+    run_command(download_ergo_jar)
+    print(f"[Success] Ergo Node version {new_version} downloaded successfully.\n")
+
+def update_systemd_service(node_path, new_version):
+    service_file_path = "/etc/systemd/system/ergo-node.service"
+
+    # Read the existing service file
+    try:
+        with open(service_file_path, "r") as service_file:
+            service_contents = service_file.read()
+    except Exception as e:
+        print(f"\n[Error] Failed to read service file: {e}\n")
+        sys.exit(1)
+
+    # Replace the ExecStart line with the new version
+    new_exec_start = f"ExecStart=/usr/bin/java -Xmx4g -jar {node_path}/ergo-node/ergo-{new_version}.jar --mainnet -c {node_path}/ergo-node/ergo.conf"
+    service_lines = service_contents.splitlines()
+    for i, line in enumerate(service_lines):
+        if line.startswith("ExecStart="):
+            service_lines[i] = new_exec_start
+            break
+
+    new_service_contents = "\n".join(service_lines)
+
+    # Write the updated service file to a temporary location
+    temp_service_file = os.path.join(os.getcwd(), 'ergo-node.service')
+    try:
+        with open(temp_service_file, "w") as service_file:
+            service_file.write(new_service_contents)
+        print(f"[Success] Updated service file created at {temp_service_file}")
+    except Exception as e:
+        print(f"\n[Error] Failed to write updated service file: {e}\n")
+        sys.exit(1)
+
+    # Move the updated service file to /etc/systemd/system/
+    run_sudo_command(f"mv {temp_service_file} {service_file_path}")
+    run_sudo_command(f"chmod 644 {service_file_path}")
+    print(f"[Success] Service file updated at {service_file_path}\n")
+
+def restart_ergo_node_service():
+    print("[Info] Restarting Ergo Node service...")
+    run_sudo_command("systemctl daemon-reload")
+    run_sudo_command("systemctl restart ergo-node.service")
+    print("[Success] Ergo Node service restarted.\n")
+
+def main():
+    print("\n#############################################")
+    print("#         Ergo Node Update Script           #")
+    print("#############################################\n")
+    print("\nAssumes ergo_node_setup.py script has already been run.\n")
+
+    # Get the user's home directory
+    home_dir = os.path.expanduser("~")
+
+    # Assume the node is installed in the user's home directory
+    node_path = home_dir
+
+    # Get the current Ergo version
+    current_version = get_current_ergo_version(node_path)
+    if not current_version:
+        print("[Error] Could not determine the current Ergo Node version.")
+        sys.exit(1)
+
+    print(f"[Info] Current Ergo Node version: {current_version}")
+
+    # Prompt user for the new Ergo version
+    new_version_input = input(f"Enter the new Ergo version to install (current is {current_version}): ").strip()
+    if not new_version_input:
+        print("[Error] No version entered. Exiting.")
+        sys.exit(1)
+    new_version = new_version_input
+    print(f"[Input] New Ergo version: {new_version}\n")
+
+    if new_version == current_version:
+        print("[Info] The new version is the same as the current version. No update needed.")
+        sys.exit(0)
+
+    # Confirm with the user
+    confirm = input(f"Are you sure you want to update from version {current_version} to {new_version}? (yes/no): ").strip().lower()
+    if confirm not in ['yes', 'y']:
+        print("Update canceled.")
+        sys.exit(0)
+
+    # Perform the update
+    update_ergo_node(node_path, new_version)
+    update_systemd_service(node_path, new_version)
+    restart_ergo_node_service()
+
+    print("#############################################")
+    print("#      Ergo Node Update Complete!           #")
+    print("#############################################\n")
+
+    print(f"[Success] Your Ergo Node has been updated to version {new_version}.\n")
+
+if __name__ == "__main__":
+    main()

--- a/resources/ergo_node_update_readme.md
+++ b/resources/ergo_node_update_readme.md
@@ -5,6 +5,7 @@ This assumes that you have basic knowledge of Raspberry Pi and Linux system admi
 ## Prerequisites
 
 - The script assumes that you have installed the Ergo Node using 'ergo_node_setup.py'.
+- You must have root privileges to run this script (use 'sudo').
 - The node should be installed in the default directory: '~/ergo-node'.
 - You must have sudo privileges to move files and restart services.
 
@@ -19,7 +20,7 @@ chmod +x ergo_node_update.py
 Run the program
 
 ```bash
-python3 ergo_node_update.py
+sudo python3 ergo_node_update.py
 ```
 
 The program will start and guide you through the Ergo Node setup process. Follow the prompts, and leave the prompt blank to use default settings when applicable.

--- a/resources/ergo_node_update_readme.md
+++ b/resources/ergo_node_update_readme.md
@@ -1,0 +1,61 @@
+# Ergo Node Python Script Update Tutorial
+
+This assumes that you have basic knowledge of Raspberry Pi and Linux system administration.
+
+## Prerequisites
+
+- The script assumes that you have installed the Ergo Node using 'ergo_node_setup.py'.
+- The node should be installed in the default directory: '~/ergo-node'.
+- You must have sudo privileges to move files and restart services.
+
+## Make the Update
+
+Make the program script executable using the following command (first time only):
+
+```bash
+chmod +x ergo_node_update.py
+```
+
+Run the program
+
+```bash
+python3 ergo_node_update.py
+```
+
+The program will start and guide you through the Ergo Node setup process. Follow the prompts, and leave the prompt blank to use default settings when applicable.
+
+**Important:** The program will perform tasks that require administrative (sudo) privileges. You may be prompted to enter your password during the execution of certain commands.
+
+---------------
+
+## Ergo Node Update Script Description
+
+This script automates the process of updating your Ergo Node to the latest mainnet release.
+It performs the following tasks:
+
+1. Determines the current version of the Ergo Node installed.
+2. Fetches the latest mainnet release version from the Ergo GitHub repository.
+3. Compares the current version with the latest version.
+   - If already running the latest version, it provides proofs and exits.
+4. Prompts the user to confirm updating to the latest version.
+5. Downloads the latest Ergo Node JAR file.
+6. Updates the systemd service file to point to the new JAR version.
+7. Restarts the Ergo Node service to apply the changes.
+8. Provides confirmation and instructions to verify the update.
+
+
+
+## Ergo Node Command Aliases
+
+Aliases were configured for your node to make node interaction easier:
+
+```bash 
+ergo-status     shows the status of the node.
+ergo-start      will start the node service.
+ergo-stop       will end the node service.
+ergo-restart    will restart the node.
+ergo-help       will show all node commands.
+ergo-logs       shows the log file of the node.
+```
+---
+


### PR DESCRIPTION
Run this script to make ergo node mainnet version updates. Here tested for 5.0.22 to 5.0.23.
- Script checks ergo releases for mainnet
- Automatically pulls jar and opens
- Updates systemd file
- restarts the node